### PR TITLE
Autogrow removed, causing editing bugs

### DIFF
--- a/src/assets/views/mock-responses-edit.hbs
+++ b/src/assets/views/mock-responses-edit.hbs
@@ -96,7 +96,7 @@ function beautifyJSON() {
 
     <div class="res_body column">
       <label for="res_body">Body</label>
-      <textarea id="res_body" required oninput="autoGrow(this)">{{mockResponse.res_body}}</textarea>
+      <textarea id="res_body" required>{{mockResponse.res_body}}</textarea>
     </div>
   </fieldset>
 


### PR DESCRIPTION
When editing a body, the page shifts up to centre the cursor where user is typing. Reported as annoying. 
"Remove this" - Karan.